### PR TITLE
chore: update node engine version to 22.0 at minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "eslint-config-next": "12.2.5",
     "postcss": "^8.4.16",
     "tailwindcss": "^3.1.8"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
Upgrade package.json by adding engine version and setting it to 22.x